### PR TITLE
feet: direct presence feature flag

### DIFF
--- a/app/bss/adapters/__init__.py
+++ b/app/bss/adapters/__init__.py
@@ -148,6 +148,7 @@ class BSSAdapter(SessionManagement, OTPHandler,
         NOTIFICATIONS_PUSH=dict(default=False, option=Capabilities.notifications_push),
         SIP_PRESENCE=dict(default=True, option=Capabilities.sip_presence),
         SIP_DIALOGS=dict(default=True, option=Capabilities.sip_dialogs),
+        DIRECT_PRESENCE=dict(default=True, option=Capabilities.direct_presence),
     )
     # what our adapter can do in general (what is coded)
     # should be overridden in the sub-class

--- a/app/bss/adapters/portaswitch/adapter.py
+++ b/app/bss/adapters/portaswitch/adapter.py
@@ -129,7 +129,8 @@ class PortaSwitchAdapter(BSSAdapter):
         Capabilities.notifications,
         Capabilities.notifications_push,
         Capabilities.sip_presence,
-        Capabilities.sip_dialogs
+        Capabilities.sip_dialogs,
+        Capabilities.direct_presence
     ]
 
     def __init__(self, config: AppConfig):

--- a/app/bss/models.py
+++ b/app/bss/models.py
@@ -590,6 +590,7 @@ class SupportedEnum(Enum):
     notifications_push = "notificationsPush"
     sip_presence = "sipPresence"
     sip_dialogs = "sipDialogs"
+    direct_presence = "directPresence"
 
 
 class SystemInfoShowResponse(BaseModel):


### PR DESCRIPTION
This pull request adds support for the new `direct_presence` capability across the BSS adapter system. The changes ensure that this capability is recognized and handled consistently in the capability definitions, adapter classes, and related enums.

Capability support extension:

* Added `DIRECT_PRESENCE` to the `capabilities` dictionary in `BSSAdapter`, enabling base support for direct presence functionality.
* Included `Capabilities.direct_presence` in the `SUPPORTED_CAPABILITIES` list of `PortaSwitchAdapter`, allowing this adapter to advertise and utilize the new capability.
* Added `direct_presence` to the `SupportedEnum` enum in `models.py`, ensuring the capability is available as an option throughout the system.